### PR TITLE
Python upgrade

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "tribler"]
 	path = tribler
 	url = https://github.com/Tribler/tribler.git
+	branch = devel

--- a/plebnet/agent/strategies/constant_sell.py
+++ b/plebnet/agent/strategies/constant_sell.py
@@ -1,7 +1,7 @@
 from plebnet.controllers import wallet_controller
 from plebnet.utilities import logger
 from plebnet.utilities.btc import satoshi_to_btc
-from strategy import Strategy
+from plebnet.agent.strategies.strategy import Strategy
 
 from plebnet.settings import plebnet_settings
 

--- a/plebnet/agent/strategies/last_day_sell.py
+++ b/plebnet/agent/strategies/last_day_sell.py
@@ -1,7 +1,7 @@
 from plebnet.controllers import wallet_controller
 from plebnet.utilities import logger
 from plebnet.utilities.btc import satoshi_to_btc
-from strategy import Strategy
+from plebnet.agent.strategies.strategy import Strategy
 
 from plebnet.settings import plebnet_settings
 

--- a/plebnet/agent/strategies/simple_moving_average.py
+++ b/plebnet/agent/strategies/simple_moving_average.py
@@ -8,7 +8,7 @@ from plebnet.controllers import market_controller
 from plebnet.settings import plebnet_settings
 from plebnet.utilities import logger
 from plebnet.utilities.btc import satoshi_to_btc
-from strategy import Strategy
+from plebnet.agent.strategies.strategy import Strategy
 from datetime import datetime, timedelta
 from math import sqrt
 

--- a/plebnet/controllers/cloudomate_controller.py
+++ b/plebnet/controllers/cloudomate_controller.py
@@ -23,7 +23,6 @@ from cloudomate.util.settings import Settings as AccountSettings
 from cloudomate.hoster.vps.proxhost import ProxHost
 
 from plebnet.agent.config import PlebNetConfig
-from plebnet.controllers import market_controller
 from plebnet.controllers.wallet_controller import TriblerWallet
 from plebnet.settings import plebnet_settings
 from plebnet.utilities import logger

--- a/plebnet/controllers/wallet_controller.py
+++ b/plebnet/controllers/wallet_controller.py
@@ -6,7 +6,7 @@ this code. If Tribler alters its web API, this should be the only file which nee
 in PlebNet.
 """
 
-import market_controller as marketcontroller
+import plebnet.controllers.market_controller as marketcontroller
 import plebnet.settings.plebnet_settings as plebnet_settings
 import requests
 from requests.exceptions import ConnectionError

--- a/plebnet/utilities/fake_generator.py
+++ b/plebnet/utilities/fake_generator.py
@@ -8,7 +8,7 @@ The only method to call is the generate_child_account(), which returns a random 
 """
 
 # Total imports
-import ConfigParser
+import configparser as ConfigParser
 import codecs
 import random
 import unicodedata

--- a/tests/agent/strategies/test_constant_sell.py
+++ b/tests/agent/strategies/test_constant_sell.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mock.mock import MagicMock
+from unittest.mock import MagicMock
 
 from plebnet.agent import core
 from plebnet.agent.strategies.constant_sell import ConstantSell

--- a/tests/agent/strategies/test_last_day_sell.py
+++ b/tests/agent/strategies/test_last_day_sell.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mock.mock import MagicMock
+from unittest.mock import MagicMock
 
 from plebnet.agent import core
 from plebnet.agent.strategies.last_day_sell import LastDaySell

--- a/tests/agent/strategies/test_simple_moving_average.py
+++ b/tests/agent/strategies/test_simple_moving_average.py
@@ -2,8 +2,8 @@ from datetime import datetime
 import time
 import unittest
 
-from mock.mock import MagicMock
-import mock
+from unittest.mock import MagicMock
+import unittest.mock as mock
 
 from plebnet.agent import core
 from plebnet.agent.strategies.last_day_sell import LastDaySell

--- a/tests/agent/strategies/test_strategy.py
+++ b/tests/agent/strategies/test_strategy.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mock.mock import MagicMock
+from unittest.mock import MagicMock
 
 from plebnet.agent.config import PlebNetConfig
 import plebnet.controllers.market_controller as market

--- a/tests/agent/test_core.py
+++ b/tests/agent/test_core.py
@@ -1,7 +1,7 @@
 import copy
 import unittest
 from unittest import skip
-import mock
+import unittest.mock as mock
 
 from CaseInsensitiveDict import CaseInsensitiveDict
 from cloudomate.hoster.vps.vps_hoster import VpsOption

--- a/tests/agent/test_core.py
+++ b/tests/agent/test_core.py
@@ -13,13 +13,11 @@ from plebnet.clone import server_installer
 from plebnet.controllers import tribler_controller, cloudomate_controller, market_controller, wallet_controller
 from plebnet.communication.irc import irc_handler
 from plebnet.settings import plebnet_settings
-from mock.mock import MagicMock
+from unittest.mock import MagicMock
 from plebnet.utilities import logger, fake_generator
 import plebnet.agent.core as Core
 import subprocess
 import os
-import re
-from appdirs import user_config_dir
 import cloudomate.hoster.vps.blueangelhost as blueAngel
 
 

--- a/tests/agent/test_qtable.py
+++ b/tests/agent/test_qtable.py
@@ -1,12 +1,12 @@
 import copy
 import random
 import unittest
-import mock
+import unittest.mock as mock
 import cloudomate.hoster.vps.blueangelhost as blueAngel
 from CaseInsensitiveDict import CaseInsensitiveDict
 
 from cloudomate.hoster.vps.vps_hoster import VpsOption
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from plebnet.agent.qtable import QTable, VPSState, ProviderOffer
 from plebnet.controllers import cloudomate_controller

--- a/tests/clone/test_server_installer.py
+++ b/tests/clone/test_server_installer.py
@@ -11,7 +11,7 @@ from plebnet.agent.qtable import QTable
 from plebnet.utilities import fake_generator
 from cloudomate.util.settings import Settings
 from plebnet.settings import plebnet_settings as setup
-from mock.mock import MagicMock
+from unittest.mock import MagicMock
 from plebnet.utilities import logger as Logger
 
 test_log_path = os.path.join(user_config_dir(), 'tests_logs')

--- a/tests/clone/test_server_installer.py
+++ b/tests/clone/test_server_installer.py
@@ -1,5 +1,5 @@
 import unittest
-import mock
+import unittest.mock as mock
 import os
 import subprocess
 

--- a/tests/communication/irc/test_irc_handler.py
+++ b/tests/communication/irc/test_irc_handler.py
@@ -1,7 +1,7 @@
 import unittest
 import subprocess
 
-from mock.mock import MagicMock
+from unittest.mock import MagicMock
 from plebnet.communication.irc import irc_handler
 from plebnet.settings import plebnet_settings
 

--- a/tests/communication/irc/test_ircbot.py
+++ b/tests/communication/irc/test_ircbot.py
@@ -2,7 +2,7 @@ import unittest
 
 from plebnet.communication.irc import ircbot
 from plebnet.settings import plebnet_settings
-from mock.mock import MagicMock
+from unittest.mock import MagicMock
 
 
 line_join = "376 " + plebnet_settings.get_instance().irc_nick()

--- a/tests/controllers/test_cloudomate_controller.py
+++ b/tests/controllers/test_cloudomate_controller.py
@@ -1,7 +1,7 @@
 import os
 import random
 import unittest
-import mock
+import unittest.mock as mock
 
 import cloudomate.hoster.vps.blueangelhost as blueAngel
 import cloudomate.hoster.vps.linevast as linevast
@@ -12,7 +12,7 @@ from cloudomate import wallet as wallet_util
 from cloudomate.hoster.vps.clientarea import ClientArea
 from cloudomate.util.settings import Settings
 from cloudomate.cmdline import providers as cloudomate_providers
-from mock.mock import MagicMock
+from unittest.mock import MagicMock
 from plebnet.communication import git_issuer
 
 import plebnet.controllers.cloudomate_controller as cloudomate

--- a/tests/controllers/test_market_controller.py
+++ b/tests/controllers/test_market_controller.py
@@ -2,7 +2,7 @@ import unittest
 import responses
 import plebnet.controllers.market_controller as Market
 import requests
-from mock.mock import MagicMock
+from unittest.mock import MagicMock
 from plebnet.utilities import logger
 
 

--- a/tests/controllers/test_tribler_controller.py
+++ b/tests/controllers/test_tribler_controller.py
@@ -3,7 +3,7 @@ import subprocess
 import responses
 import requests
 import plebnet.controllers.tribler_controller as Tribler
-from mock.mock import MagicMock
+from unittest.mock import MagicMock
 from plebnet.utilities import logger
 import plebnet.settings.plebnet_settings as Settings
 

--- a/tests/controllers/test_wallet_controller.py
+++ b/tests/controllers/test_wallet_controller.py
@@ -8,7 +8,7 @@ import plebnet.controllers.wallet_controller as walletcontroller
 import plebnet.controllers.market_controller as marketcontroller
 import plebnet.settings.plebnet_settings as plebnet_settings
 
-from mock.mock import MagicMock
+from unittest.mock import MagicMock
 from plebnet.utilities import logger
 
 

--- a/tests/utilities/test_fake_generator.py
+++ b/tests/utilities/test_fake_generator.py
@@ -1,8 +1,8 @@
 import unittest
-import mock
+import unittest.mock as mock
 from appdirs import user_config_dir
 import os
-from cloudomate.util.settings import Settings
+import cloudomate.util.settings as settings
 from plebnet.utilities import fake_generator
 
 
@@ -27,7 +27,7 @@ class TestFakeGenerator(unittest.TestCase):
     @mock.patch('plebnet.utilities.fake_generator._child_file', return_value=test_file)
     def test_generate_child_has_content(self, mock):
         fake_generator.generate_child_account()
-        account = Settings()
+        account = settings.Settings()
         account.read_settings(test_file)
 
         self.assertIsNotNone(account.get('user', 'email'))

--- a/tests/utilities/test_logger.py
+++ b/tests/utilities/test_logger.py
@@ -1,6 +1,5 @@
 import unittest
-import mock
-from mock.mock import MagicMock
+
 from appdirs import user_config_dir
 import os
 import sys


### PR DESCRIPTION
Main changes are in import statements. Mind that now to install the right dependencies you might need to use pip3 (if your pip is managing the native 2.7 version)